### PR TITLE
Enhance Text Clarity by Correcting Name

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 ## Study group
 A month-long zkp study group, one topic at a time.
 - Jolt -> Finished
-- Binius -> [Binus学习小组 Finished](https://github.com/Antalpha-Labs/zkp-academy/issues/5) 
+- Binus -> [Binus学习小组 Finished](https://github.com/Antalpha-Labs/zkp-academy/issues/5) 
 - Circle Starks -> [Finished](https://github.com/Antalpha-Labs/zkp-academy/issues/61)
 
 ### 🔥 zkp-academy Contributors

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 ## Study group
 A month-long zkp study group, one topic at a time.
 - Jolt -> Finished
-- Binus -> [Binus学习小组 Finished](https://github.com/Antalpha-Labs/zkp-academy/issues/5) 
+- Binius -> [Binius学习小组 Finished](https://github.com/Antalpha-Labs/zkp-academy/issues/5) 
 - Circle Starks -> [Finished](https://github.com/Antalpha-Labs/zkp-academy/issues/61)
 
 ### 🔥 zkp-academy Contributors


### PR DESCRIPTION
### Change from "Binius" to "Binus":
**Explanation: This correction is important for accuracy and minimizing confusion. The names of study groups or organizations should be presented correctly to avoid misunderstandings among participants or new readers.**